### PR TITLE
fix: intercept tool_use turn to prevent MCP placeholder leak

### DIFF
--- a/src/tools/tool-translator.ts
+++ b/src/tools/tool-translator.ts
@@ -65,3 +65,17 @@ export function writeTempMcpConfig(mcpConfig: McpConfig): { configPath: string; 
 export function emptyMcpConfig(): McpConfig {
   return { mcpServers: {} };
 }
+
+/**
+ * The MCP server name used for client-defined tools.
+ * The CLI prefixes tool names with `mcp__<server_name>__`.
+ */
+const MCP_TOOL_PREFIX = 'mcp__client_tools__';
+
+/**
+ * Strip the `mcp__client_tools__` prefix that the CLI adds to MCP tool names.
+ * Returns the original tool name as defined by the client.
+ */
+export function stripMcpToolPrefix(name: string): string {
+  return name.startsWith(MCP_TOOL_PREFIX) ? name.slice(MCP_TOOL_PREFIX.length) : name;
+}

--- a/src/translation/cli-to-anthropic-stream.ts
+++ b/src/translation/cli-to-anthropic-stream.ts
@@ -1,5 +1,6 @@
 import type { CliEvent, StreamInnerEvent } from '../protocol/cli-types.js';
 import { logger } from '../util/logger.js';
+import { stripMcpToolPrefix } from '../tools/tool-translator.js';
 
 function formatSSE(event: StreamInnerEvent): string {
   return `event: ${event.type}\ndata: ${JSON.stringify(event)}\n\n`;
@@ -15,11 +16,25 @@ export async function* cliToAnthropicSSE(
   enableThinking: boolean,
 ): AsyncGenerator<string> {
   const filteredIndices = new Set<number>();
+  let sawToolUseStop = false;
 
   for await (const event of events) {
     switch (event.type) {
       case 'stream_event': {
         const inner = event.event;
+
+        // Strip MCP prefix from tool_use block names
+        if (
+          inner.type === 'content_block_start' &&
+          inner.content_block.type === 'tool_use'
+        ) {
+          inner.content_block.name = stripMcpToolPrefix(inner.content_block.name);
+        }
+
+        // Track tool_use stop reason for multi-turn interception
+        if (inner.type === 'message_delta' && inner.delta.stop_reason === 'tool_use') {
+          sawToolUseStop = true;
+        }
 
         // Filter thinking blocks if not enabled
         if (!enableThinking) {
@@ -46,6 +61,15 @@ export async function* cliToAnthropicSSE(
         }
 
         yield formatSSE(inner);
+
+        // After yielding message_stop for a tool_use turn, stop the stream.
+        // The CLI would continue into a second turn with the MCP bridge's
+        // placeholder result — that garbage must never reach the client.
+        if (inner.type === 'message_stop' && sawToolUseStop) {
+          logger.debug('Stopping stream after tool_use turn (intercepting MCP placeholder turn)');
+          return;
+        }
+
         break;
       }
 

--- a/src/translation/cli-to-anthropic.ts
+++ b/src/translation/cli-to-anthropic.ts
@@ -2,6 +2,7 @@ import type { CliEvent } from '../protocol/cli-types.js';
 import type { AnthropicMessagesResponse, AnthropicResponseContentBlock, AnthropicUsage } from '../protocol/anthropic-types.js';
 import { logger } from '../util/logger.js';
 import { serverError, rateLimited } from '../util/errors.js';
+import { stripMcpToolPrefix } from '../tools/tool-translator.js';
 
 /**
  * Collect all CLI events and build a non-streaming Anthropic Messages response.
@@ -17,10 +18,11 @@ export async function collectAnthropicResponse(
   const contentBlocks: AnthropicResponseContentBlock[] = [];
   let usage: AnthropicUsage = { input_tokens: 0, output_tokens: 0 };
   let hasResult = false;
+  let sawToolUseStop = false;
   // Track partial JSON accumulation for tool_use blocks by index
   const partialJsonByIndex = new Map<number, string>();
 
-  for await (const event of events) {
+  eventLoop: for await (const event of events) {
     switch (event.type) {
       case 'stream_event': {
         const inner = event.event;
@@ -44,7 +46,7 @@ export async function collectAnthropicResponse(
             contentBlocks[inner.index] = {
               type: 'tool_use',
               id: block.id,
-              name: block.name,
+              name: stripMcpToolPrefix(block.name),
               input: {},
             };
           } else if (block.type === 'thinking' && enableThinking) {
@@ -95,6 +97,17 @@ export async function collectAnthropicResponse(
           if (inner.usage) {
             usage.output_tokens = inner.usage.output_tokens;
           }
+          if (stopReason === 'tool_use') {
+            sawToolUseStop = true;
+          }
+        }
+
+        // After message_stop for a tool_use turn, stop consuming events.
+        // The CLI would continue into a second turn with the MCP bridge's
+        // placeholder result — that garbage must never reach the client.
+        if (inner.type === 'message_stop' && sawToolUseStop) {
+          logger.debug('Stopping event collection after tool_use turn (intercepting MCP placeholder turn)');
+          break eventLoop;
         }
 
         break;

--- a/src/translation/cli-to-openai-stream.ts
+++ b/src/translation/cli-to-openai-stream.ts
@@ -1,6 +1,7 @@
 import type { CliEvent } from '../protocol/cli-types.js';
 import type { OpenAIChatCompletionChunk } from '../protocol/openai-types.js';
 import { logger } from '../util/logger.js';
+import { stripMcpToolPrefix } from '../tools/tool-translator.js';
 
 function makeChunk(
   id: string,
@@ -28,6 +29,7 @@ export async function* cliToOpenAISSE(
   let model = '';
   let toolCallIndex = -1;
   let sentRole = false;
+  let sawToolUseStop = false;
 
   for await (const event of events) {
     if (event.type !== 'stream_event') {
@@ -64,7 +66,7 @@ export async function* cliToOpenAISSE(
               index: toolCallIndex,
               id: block.id,
               type: 'function',
-              function: { name: block.name, arguments: '' },
+              function: { name: stripMcpToolPrefix(block.name), arguments: '' },
             }],
           }, null);
           yield `data: ${JSON.stringify(chunk)}\n\n`;
@@ -96,6 +98,7 @@ export async function* cliToOpenAISSE(
         let finishReason: 'stop' | 'tool_calls' | 'length' = 'stop';
         if (inner.delta.stop_reason === 'tool_use') {
           finishReason = 'tool_calls';
+          sawToolUseStop = true;
         } else if (inner.delta.stop_reason === 'max_tokens') {
           finishReason = 'length';
         }
@@ -104,8 +107,19 @@ export async function* cliToOpenAISSE(
         break;
       }
 
+      case 'message_stop': {
+        // After message_stop for a tool_use turn, emit [DONE] and stop.
+        // The CLI would continue into a second turn with the MCP bridge's
+        // placeholder result — that garbage must never reach the client.
+        if (sawToolUseStop) {
+          logger.debug('Stopping stream after tool_use turn (intercepting MCP placeholder turn)');
+          yield 'data: [DONE]\n\n';
+          return;
+        }
+        break;
+      }
+
       case 'content_block_stop':
-      case 'message_stop':
         break;
 
       default:

--- a/src/translation/cli-to-openai.ts
+++ b/src/translation/cli-to-openai.ts
@@ -2,6 +2,7 @@ import type { CliEvent } from '../protocol/cli-types.js';
 import type { OpenAIChatCompletionResponse, OpenAIToolCall, OpenAICompletionUsage } from '../protocol/openai-types.js';
 import { logger } from '../util/logger.js';
 import { serverError, rateLimited } from '../util/errors.js';
+import { stripMcpToolPrefix } from '../tools/tool-translator.js';
 
 interface AccumulatedToolCall {
   id: string;
@@ -22,8 +23,9 @@ export async function collectOpenAIResponse(
   const toolCalls: AccumulatedToolCall[] = [];
   let currentToolCallIndex = -1;
   let usage: OpenAICompletionUsage = { prompt_tokens: 0, completion_tokens: 0, total_tokens: 0 };
+  let sawToolUseStop = false;
 
-  for await (const event of events) {
+  eventLoop: for await (const event of events) {
     switch (event.type) {
       case 'stream_event': {
         const inner = event.event;
@@ -39,7 +41,7 @@ export async function collectOpenAIResponse(
             currentToolCallIndex++;
             toolCalls.push({
               id: inner.content_block.id,
-              name: inner.content_block.name,
+              name: stripMcpToolPrefix(inner.content_block.name),
               partialJson: '',
             });
           }
@@ -56,6 +58,7 @@ export async function collectOpenAIResponse(
         if (inner.type === 'message_delta') {
           if (inner.delta.stop_reason === 'tool_use') {
             finishReason = 'tool_calls';
+            sawToolUseStop = true;
           } else if (inner.delta.stop_reason === 'max_tokens') {
             finishReason = 'length';
           } else {
@@ -63,6 +66,14 @@ export async function collectOpenAIResponse(
           }
           usage.completion_tokens = inner.usage.output_tokens;
           usage.total_tokens = usage.prompt_tokens + usage.completion_tokens;
+        }
+
+        // After message_stop for a tool_use turn, stop consuming events.
+        // The CLI would continue into a second turn with the MCP bridge's
+        // placeholder result — that garbage must never reach the client.
+        if (inner.type === 'message_stop' && sawToolUseStop) {
+          logger.debug('Stopping event collection after tool_use turn (intercepting MCP placeholder turn)');
+          break eventLoop;
         }
 
         break;


### PR DESCRIPTION
## Summary
- Strip the `mcp__client_tools__` prefix the CLI adds to MCP tool names so clients see their original tool names
- Stop consuming CLI events after `message_stop` on tool_use turns, preventing the MCP bridge's placeholder second turn from leaking garbage to the client
- Applied consistently across all four response translators (Anthropic streaming/non-streaming, OpenAI streaming/non-streaming)

Closes #1

## Test plan
- [x] Send a tool-calling request via the Anthropic `/v1/messages` endpoint (streaming) — verify `tool_use` blocks have unprefixed names and `stop_reason: "tool_use"`
- [x] Same via non-streaming Anthropic — verify response shape
- [x] Send a tool-calling request via the OpenAI `/v1/chat/completions` endpoint (streaming) — verify `tool_calls` with unprefixed names and `finish_reason: "tool_calls"`
- [x] Same via non-streaming OpenAI — verify response shape
- [x] Confirm no second-turn garbage appears in any mode
- [x] `npm run build` compiles with zero errors

🤖 Generated with [Claude Code](https://claude.com/claude-code)