### PR TITLE
fix: remove process→Bash collision in OpenClaw tool map

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -250,7 +250,6 @@ Client tool names are mapped to Claude Code equivalents for better model perform
 | `web_search` | `WebSearch` |
 | `web_fetch` | `WebFetch` |
 | `browser` | `Browser` |
-| `process` | `Bash` |
 | `canvas` | `Canvas` |
 
 Tool names are mapped forward in requests and reverse-mapped in responses so clients see their original names.

--- a/src/openclaw/tool-map.ts
+++ b/src/openclaw/tool-map.ts
@@ -10,6 +10,7 @@
  */
 
 import type { AnthropicToolDefinition } from '../protocol/anthropic-types.js';
+import { logger } from '../util/logger.js';
 
 const OPENCLAW_TO_CLAUDE: Record<string, string> = {
   exec: 'Bash',
@@ -19,7 +20,6 @@ const OPENCLAW_TO_CLAUDE: Record<string, string> = {
   web_search: 'WebSearch',
   web_fetch: 'WebFetch',
   browser: 'Browser',
-  process: 'Bash',
   canvas: 'Canvas',
 };
 
@@ -41,8 +41,16 @@ export function mapToolDefinitions(
 ): { mappedTools: AnthropicToolDefinition[]; reverseToolMap: Record<string, string> } {
   const reverseToolMap: Record<string, string> = {};
 
+  const seenNames = new Map<string, string>();
+
   const mappedTools = tools.map(tool => {
     const mapped = mapToolName(tool.name);
+    const previous = seenNames.get(mapped);
+    if (previous) {
+      logger.warn(`Tool name collision: "${tool.name}" and "${previous}" both map to "${mapped}". Skipping "${tool.name}" to avoid overwrite.`);
+      return { ...tool };
+    }
+    seenNames.set(mapped, tool.name);
     if (mapped !== tool.name) {
       reverseToolMap[mapped] = tool.name;
     }


### PR DESCRIPTION
## Summary

- Remove `process: 'Bash'` mapping from `OPENCLAW_TO_CLAUDE` that collided with `exec: 'Bash'`, causing MCP bridge schema overwrites and reverse-map corruption that put OpenClaw agents into infinite retry loops
- Add collision detection in `mapToolDefinitions` that logs a warning and skips duplicate mappings to prevent similar bugs
- Update `CLAUDE.md` tool mapping table

Closes #7

## Test plan

- [ ] Verify `npm run build` compiles cleanly
- [ ] Send a request with both `exec` and `process` tools — confirm `exec` maps to `Bash` and `process` keeps its original name
- [ ] Confirm response tool_use blocks reverse-map `Bash` back to `exec` (not `process`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)