### PR TITLE
[codex] Fix model family resolution

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -105,7 +105,7 @@ src/
 - `src/translation/anthropic-to-cli.ts` — `messagesToPrompt()` flattens the messages array into a single string. Multi-turn uses `<assistant_response>` and `<tool_result>` XML tags.
 
 ### "I need to add/change a model"
-- `src/translation/model-map.ts` — `MODEL_ALIASES` maps all accepted names to CLI model names. `EFFORT_BY_MODEL` defines effort constraints per model. `CLI_TO_API_MODEL` maps back for responses.
+- `src/translation/model-map.ts` — model names resolve by family prefix (`opus`, `sonnet`, `haiku`) after stripping known wrappers like `claude-code-cli/` and `openai/`. `EFFORT_BY_MODEL` defines effort constraints per family.
 
 ### "I need to change how responses are translated"
 - Anthropic streaming: `src/translation/cli-to-anthropic-stream.ts` — near pass-through of CLI `stream_event` inner events
@@ -143,7 +143,7 @@ src/
 | `PROXY_API_KEYS` | *(none)* | Comma-separated bearer tokens |
 | `REQUIRE_AUTH` | `true` | Set `false` to disable auth |
 | `CLAUDE_PATH` | `claude` | Path to Claude CLI binary |
-| `DEFAULT_MODEL` | `sonnet` | Fallback model |
+| `DEFAULT_MODEL` | `sonnet` | Reserved default model setting; unknown request models now return 400 |
 | `DEFAULT_EFFORT` | `high` | Default effort level |
 | `REQUEST_TIMEOUT_MS` | `300000` | Per-request timeout (5 min) |
 | `LOG_LEVEL` | `info` | `debug` / `info` / `warn` / `error` |
@@ -160,15 +160,15 @@ src/
 
 ## Model Names
 
-Any of these are accepted in the `model` field:
+Accepted model names resolve by family prefix. The proxy strips `claude-code-cli/` and `openai/`, then matches `opus`, `sonnet`, or `haiku` with any optional suffix.
 
-| Aliases | CLI Model | Response Model ID |
+| Examples Accepted | CLI Model | `/v1/models` ID |
 |---|---|---|
-| `claude-opus-4-6`, `claude-opus-4`, `opus`, `opus-4`, `opus-4-6` | `opus` | `claude-opus-4-6` |
-| `claude-sonnet-4-6`, `claude-sonnet-4`, `sonnet`, `sonnet-4`, `sonnet-4-6` | `sonnet` | `claude-sonnet-4-6` |
-| `claude-haiku-4-5`, `claude-haiku-4`, `haiku`, `haiku-4`, `haiku-4-5` | `haiku` | `claude-haiku-4-5` |
+| `opus`, `claude-opus-4-6`, `claude-opus-4-7`, `opus-5` | `opus` | `claude-opus-4-6` |
+| `sonnet`, `claude-sonnet-4-6`, `sonnet-4-7` | `sonnet` | `claude-sonnet-4-6` |
+| `haiku`, `claude-haiku-4-5`, `haiku-5` | `haiku` | `claude-haiku-4-5` |
 
-Model names with the `claude-code-cli/` or `openai/` prefix are also accepted (the prefix is stripped before lookup). Unknown models fall back to `DEFAULT_MODEL`.
+Model names with the `claude-code-cli/` or `openai/` prefix are also accepted (the prefix is stripped before lookup). Unknown model families return HTTP 400 instead of falling back to `DEFAULT_MODEL`.
 
 ## Effort Levels
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -226,6 +226,23 @@ Types are defined in `src/protocol/cli-types.ts`.
 
 Errors are formatted as Anthropic `{type:"error",error:{type,message}}` for `/v1/messages` and OpenAI `{error:{message,type,code}}` for `/v1/chat/completions`.
 
+## Rate Limit Response Headers
+
+The proxy forwards quota information from the CLI's `rate_limit_event` as standard HTTP response headers. These values originate from Anthropic's own `anthropic-ratelimit-*` headers, which the CLI surfaces in its NDJSON event stream.
+
+| Header | Type | Format | Description |
+|---|---|---|---|
+| `x-ratelimit-limit` | Integer | e.g. `1000` | Maximum requests (or tokens) allowed in the current rate limit window |
+| `x-ratelimit-remaining` | Integer | e.g. `999` | Quota units remaining in the current window. Token values are rounded to the nearest thousand by Anthropic |
+| `x-ratelimit-reset` | String | RFC 3339 timestamp, e.g. `2026-03-19T15:30:00Z` | When the current rate limit window fully replenishes |
+
+**Availability:**
+- **Non-streaming responses** (200 OK): all three headers are set when the CLI provides rate limit info.
+- **Streaming responses** (SSE): headers cannot be set after the stream starts. On a rate-limit error during streaming, `reset_at` is included in the SSE error event body instead.
+- **429 errors**: `x-ratelimit-reset` is always set. `x-ratelimit-limit` and `x-ratelimit-remaining` are set if the CLI provides them in the `rate_limit_event`.
+
+All three headers are listed in `Access-Control-Expose-Headers` so browser clients can read them.
+
 ## Unsupported Parameters
 
 These are accepted but ignored (a `x-proxy-unsupported` response header lists them):

--- a/README.md
+++ b/README.md
@@ -115,7 +115,7 @@ Any tool with a "custom base URL" or "OpenAI-compatible" setting works:
 | **LiteLLM** | `api_base="http://localhost:4523/v1"` |
 | **OpenClaw** | `OPENAI_BASE_URL=http://host.docker.internal:4523/v1` |
 
-Use `claude-sonnet-4-6`, `claude-opus-4-6`, or `claude-haiku-4-5` as the model name (shorter aliases like `sonnet`, `opus`, `haiku` also work). Model names with a `claude-code-cli/` or `openai/` prefix are also accepted (the prefix is stripped automatically). Unknown models fall back to the `DEFAULT_MODEL`.
+Use any `sonnet`, `opus`, or `haiku` family name as the model, including versioned variants like `claude-sonnet-4-6`, `claude-opus-4-7`, `sonnet-4-7`, or `haiku-5`. Model names with a `claude-code-cli/` or `openai/` prefix are also accepted (the prefix is stripped automatically). Unknown model families return HTTP 400 instead of falling back to the `DEFAULT_MODEL`.
 
 ## Streaming
 
@@ -149,11 +149,11 @@ for await (const chunk of stream) {
 
 ## Available Models
 
-| Model Name | Aliases |
+| Family advertised at `/v1/models` | Accepted examples |
 |-----------|---------|
-| `claude-opus-4-6` | `claude-opus-4`, `opus` |
-| `claude-sonnet-4-6` | `claude-sonnet-4`, `sonnet` |
-| `claude-haiku-4-5` | `claude-haiku-4`, `haiku` |
+| `claude-opus-4-6` | `opus`, `claude-opus-4-6`, `claude-opus-4-7`, `opus-5` |
+| `claude-sonnet-4-6` | `sonnet`, `claude-sonnet-4-6`, `sonnet-4-7` |
+| `claude-haiku-4-5` | `haiku`, `claude-haiku-4-5`, `haiku-5` |
 
 ## Features
 
@@ -179,7 +179,7 @@ All settings are environment variables:
 | `PROXY_API_KEYS` | — | Comma-separated API keys for auth |
 | `REQUIRE_AUTH` | `true` | Set `false` for local use |
 | `CLAUDE_PATH` | `claude` | Path to Claude CLI |
-| `DEFAULT_MODEL` | `sonnet` | Model when not specified |
+| `DEFAULT_MODEL` | `sonnet` | Reserved default model setting; unknown request models now return 400 |
 | `DEFAULT_EFFORT` | `high` | Default effort level |
 | `REQUEST_TIMEOUT_MS` | `300000` | Request timeout (5 min) |
 | `LOG_LEVEL` | `info` | `debug`, `info`, `warn`, `error` |

--- a/README.md
+++ b/README.md
@@ -194,6 +194,20 @@ All settings are environment variables:
 | `GET` | `/v1/models` | List available models |
 | `GET` | `/health` | Health check |
 
+## Rate Limit Headers
+
+On non-streaming responses, the proxy forwards quota information from the Claude CLI as standard HTTP headers. These originate from Anthropic's own `anthropic-ratelimit-*` headers, surfaced by the CLI in its output stream.
+
+| Header | Format | Description |
+|--------|--------|-------------|
+| `x-ratelimit-limit` | Integer (e.g. `1000`) | Maximum requests/tokens allowed in the current window |
+| `x-ratelimit-remaining` | Integer (e.g. `999`) | Quota units remaining. Token values are rounded to the nearest thousand by Anthropic |
+| `x-ratelimit-reset` | RFC 3339 timestamp (e.g. `2026-03-19T15:30:00Z`) | When the current rate limit window fully replenishes |
+
+On `429` errors, `x-ratelimit-reset` is always set in the response header. For streaming responses, these headers cannot be set after the stream has started — the reset time is included in the SSE error event body (`reset_at` field) instead.
+
+All three headers are included in `Access-Control-Expose-Headers` for browser clients.
+
 ## How It Works
 
 Each API request spawns a fresh `claude --print` subprocess. The proxy translates between API formats and CLI I/O:

--- a/src/cli/args-builder.ts
+++ b/src/cli/args-builder.ts
@@ -24,7 +24,7 @@ export interface BuiltCliCommand {
 }
 
 export function buildArgs(cliArgs: CliArgs, config: Config): BuiltCliCommand {
-  const cliModel = toCliModel(cliArgs.model, config.defaultModel);
+  const cliModel = toCliModel(cliArgs.model);
 
   const args: string[] = [
     config.claudePath,

--- a/src/protocol/cli-types.ts
+++ b/src/protocol/cli-types.ts
@@ -161,6 +161,12 @@ export interface CliStreamEvent {
   session_id: string;
 }
 
+export interface RateLimitInfo {
+  limit?: number;
+  remaining?: number;
+  reset?: string;
+}
+
 export interface CliRateLimitEvent {
   type: 'rate_limit_event';
   rate_limit_info: {

--- a/src/routes/anthropic-messages.ts
+++ b/src/routes/anthropic-messages.ts
@@ -1,7 +1,7 @@
 import type { IncomingMessage, ServerResponse } from 'node:http';
 import type { Config } from '../config.js';
 import type { AnthropicMessagesRequest } from '../protocol/anthropic-types.js';
-import { parseJsonBody, addUnsupportedWarnings } from '../server/middleware.js';
+import { parseJsonBody, addUnsupportedWarnings, setRateLimitHeaders } from '../server/middleware.js';
 import { translateAnthropicRequest } from '../translation/anthropic-to-cli.js';
 import { buildArgs } from '../cli/args-builder.js';
 import { spawnCli } from '../cli/subprocess.js';
@@ -96,9 +96,10 @@ export async function handleMessages(
     }
   } else {
     try {
-      const result = await collectAnthropicResponse(events, enableThinking);
+      const { response, rateLimitInfo } = await collectAnthropicResponse(events, enableThinking);
+      if (rateLimitInfo) setRateLimitHeaders(res, rateLimitInfo);
       res.writeHead(200, { 'Content-Type': 'application/json' });
-      res.end(JSON.stringify(result));
+      res.end(JSON.stringify(response));
     } catch (err) {
       kill();
       throw err;

--- a/src/routes/openai-chat-completions.ts
+++ b/src/routes/openai-chat-completions.ts
@@ -2,7 +2,7 @@ import type { IncomingMessage, ServerResponse } from 'node:http';
 import type { Config } from '../config.js';
 import type { OpenAIChatCompletionRequest, OpenAIChatMessage } from '../protocol/openai-types.js';
 import type { AnthropicMessagesRequest, AnthropicMessage, AnthropicContentBlock, AnthropicToolDefinition, AnthropicToolChoice } from '../protocol/anthropic-types.js';
-import { parseJsonBody, addUnsupportedWarnings } from '../server/middleware.js';
+import { parseJsonBody, addUnsupportedWarnings, setRateLimitHeaders } from '../server/middleware.js';
 import { translateAnthropicRequest } from '../translation/anthropic-to-cli.js';
 import { buildArgs } from '../cli/args-builder.js';
 import { spawnCli } from '../cli/subprocess.js';
@@ -240,9 +240,10 @@ export async function handleChatCompletions(
     }
   } else {
     try {
-      const result = await collectOpenAIResponse(events, reverseToolMap);
+      const { response, rateLimitInfo } = await collectOpenAIResponse(events, reverseToolMap);
+      if (rateLimitInfo) setRateLimitHeaders(res, rateLimitInfo);
       res.writeHead(200, { 'Content-Type': 'application/json' });
-      res.end(JSON.stringify(result));
+      res.end(JSON.stringify(response));
     } catch (err) {
       kill();
       throw err;

--- a/src/server/middleware.ts
+++ b/src/server/middleware.ts
@@ -134,6 +134,18 @@ export function sendError(res: ServerResponse, err: unknown, format: ApiFormat =
 }
 
 /**
+ * Set x-ratelimit-* headers from rate limit info returned by the CLI.
+ */
+export function setRateLimitHeaders(
+  res: ServerResponse,
+  info: { limit?: number; remaining?: number; reset?: string },
+): void {
+  if (info.limit !== undefined) res.setHeader('x-ratelimit-limit', String(info.limit));
+  if (info.remaining !== undefined) res.setHeader('x-ratelimit-remaining', String(info.remaining));
+  if (info.reset !== undefined) res.setHeader('x-ratelimit-reset', info.reset);
+}
+
+/**
  * Add warning headers for unsupported parameters.
  */
 export function addUnsupportedWarnings(res: ServerResponse, params: string[]): void {

--- a/src/translation/cli-to-anthropic.ts
+++ b/src/translation/cli-to-anthropic.ts
@@ -1,4 +1,4 @@
-import type { CliEvent } from '../protocol/cli-types.js';
+import type { CliEvent, RateLimitInfo } from '../protocol/cli-types.js';
 import type { AnthropicMessagesResponse, AnthropicResponseContentBlock, AnthropicUsage } from '../protocol/anthropic-types.js';
 import { logger } from '../util/logger.js';
 import { serverError, rateLimited } from '../util/errors.js';
@@ -7,11 +7,16 @@ import { stripMcpToolPrefix } from '../tools/tool-translator.js';
 /**
  * Collect all CLI events and build a non-streaming Anthropic Messages response.
  */
+export interface AnthropicCollectResult {
+  response: AnthropicMessagesResponse;
+  rateLimitInfo?: RateLimitInfo;
+}
+
 export async function collectAnthropicResponse(
   events: AsyncGenerator<CliEvent>,
   enableThinking: boolean,
   reverseToolMap?: Record<string, string>,
-): Promise<AnthropicMessagesResponse> {
+): Promise<AnthropicCollectResult> {
   let messageId = '';
   let model = '';
   let stopReason: AnthropicMessagesResponse['stop_reason'] = null;
@@ -20,6 +25,7 @@ export async function collectAnthropicResponse(
   let usage: AnthropicUsage = { input_tokens: 0, output_tokens: 0 };
   let hasResult = false;
   let sawToolUseStop = false;
+  let rateLimitInfo: RateLimitInfo | undefined;
   // Track partial JSON accumulation for tool_use blocks by index
   const partialJsonByIndex = new Map<number, string>();
 
@@ -134,6 +140,11 @@ export async function collectAnthropicResponse(
             event.rate_limit_info.reset,
           );
         }
+        rateLimitInfo = {
+          limit: event.rate_limit_info.limit,
+          remaining: event.rate_limit_info.remaining,
+          reset: event.rate_limit_info.reset,
+        };
         break;
       }
 
@@ -154,13 +165,16 @@ export async function collectAnthropicResponse(
   const filteredContent = contentBlocks.filter((b): b is AnthropicResponseContentBlock => b != null);
 
   return {
-    id: messageId || `msg_${crypto.randomUUID().replace(/-/g, '')}`,
-    type: 'message',
-    role: 'assistant',
-    content: filteredContent,
-    model: model || 'unknown',
-    stop_reason: stopReason || 'end_turn',
-    stop_sequence: stopSequence,
-    usage,
+    response: {
+      id: messageId || `msg_${crypto.randomUUID().replace(/-/g, '')}`,
+      type: 'message',
+      role: 'assistant',
+      content: filteredContent,
+      model: model || 'unknown',
+      stop_reason: stopReason || 'end_turn',
+      stop_sequence: stopSequence,
+      usage,
+    },
+    rateLimitInfo,
   };
 }

--- a/src/translation/cli-to-openai.ts
+++ b/src/translation/cli-to-openai.ts
@@ -1,4 +1,4 @@
-import type { CliEvent } from '../protocol/cli-types.js';
+import type { CliEvent, RateLimitInfo } from '../protocol/cli-types.js';
 import type { OpenAIChatCompletionResponse, OpenAIToolCall, OpenAICompletionUsage } from '../protocol/openai-types.js';
 import { logger } from '../util/logger.js';
 import { serverError, rateLimited } from '../util/errors.js';
@@ -14,10 +14,15 @@ interface AccumulatedToolCall {
  * Collect all CLI events and build a non-streaming OpenAI Chat Completion response.
  * @param reverseToolMap - Optional map to translate CLI tool names back to client names
  */
+export interface OpenAICollectResult {
+  response: OpenAIChatCompletionResponse;
+  rateLimitInfo?: RateLimitInfo;
+}
+
 export async function collectOpenAIResponse(
   events: AsyncGenerator<CliEvent>,
   reverseToolMap?: Record<string, string>,
-): Promise<OpenAIChatCompletionResponse> {
+): Promise<OpenAICollectResult> {
   let messageId = '';
   let model = '';
   let textContent = '';
@@ -26,6 +31,7 @@ export async function collectOpenAIResponse(
   let currentToolCallIndex = -1;
   let usage: OpenAICompletionUsage = { prompt_tokens: 0, completion_tokens: 0, total_tokens: 0 };
   let sawToolUseStop = false;
+  let rateLimitInfo: RateLimitInfo | undefined;
 
   eventLoop: for await (const event of events) {
     switch (event.type) {
@@ -100,6 +106,11 @@ export async function collectOpenAIResponse(
             event.rate_limit_info.reset,
           );
         }
+        rateLimitInfo = {
+          limit: event.rate_limit_info.limit,
+          remaining: event.rate_limit_info.remaining,
+          reset: event.rate_limit_info.reset,
+        };
         break;
       }
 
@@ -126,20 +137,23 @@ export async function collectOpenAIResponse(
       : undefined;
 
   return {
-    id: messageId || `chatcmpl-${crypto.randomUUID().replace(/-/g, '')}`,
-    object: 'chat.completion',
-    created: Math.floor(Date.now() / 1000),
-    model: model || 'unknown',
-    choices: [{
-      index: 0,
-      message: {
-        role: 'assistant',
-        content: textContent || null,
-        tool_calls: openaiToolCalls,
-      },
-      finish_reason: finishReason || 'stop',
-    }],
-    usage,
-    system_fingerprint: null,
+    response: {
+      id: messageId || `chatcmpl-${crypto.randomUUID().replace(/-/g, '')}`,
+      object: 'chat.completion',
+      created: Math.floor(Date.now() / 1000),
+      model: model || 'unknown',
+      choices: [{
+        index: 0,
+        message: {
+          role: 'assistant',
+          content: textContent || null,
+          tool_calls: openaiToolCalls,
+        },
+        finish_reason: finishReason || 'stop',
+      }],
+      usage,
+      system_fingerprint: null,
+    },
+    rateLimitInfo,
   };
 }

--- a/src/translation/model-map.ts
+++ b/src/translation/model-map.ts
@@ -1,41 +1,13 @@
 import { badRequest } from '../util/errors.js';
-import { logger } from '../util/logger.js';
-
-const MODEL_ALIASES: Record<string, string> = {
-  // Opus aliases
-  'claude-opus-4-6': 'opus',
-  'claude-opus-4': 'opus',
-  'opus': 'opus',
-  'opus-4': 'opus',
-  'opus-4-6': 'opus',
-  // Sonnet aliases
-  'claude-sonnet-4-6': 'sonnet',
-  'claude-sonnet-4': 'sonnet',
-  'sonnet': 'sonnet',
-  'sonnet-4': 'sonnet',
-  'sonnet-4-6': 'sonnet',
-  // Haiku aliases
-  'claude-haiku-4-5': 'haiku',
-  'claude-haiku-4': 'haiku',
-  'haiku': 'haiku',
-  'haiku-4': 'haiku',
-  'haiku-4-5': 'haiku',
-};
 
 /**
- * Prefixes that are stripped before model alias lookup.
+ * Prefixes that are stripped before model family lookup.
  * Allows clients like OpenClaw to send e.g. "claude-code-cli/opus".
  */
 const STRIP_PREFIXES = ['claude-code-cli/', 'openai/'];
+const FAMILY_REGEX = /^(?:claude-)?(opus|sonnet|haiku)(?:[-/].*)?$/i;
 
-// Map CLI model names back to full Anthropic model IDs for responses
-const CLI_TO_API_MODEL: Record<string, string> = {
-  'opus': 'claude-opus-4-6',
-  'sonnet': 'claude-sonnet-4-6',
-  'haiku': 'claude-haiku-4-5',
-};
-
-// Effort level constraints per model
+// Effort level constraints per model family
 const EFFORT_BY_MODEL: Record<string, string[]> = {
   opus: ['low', 'medium', 'high', 'max'],
   sonnet: ['low', 'medium', 'high'],
@@ -55,29 +27,28 @@ function stripModelPrefix(model: string): string {
   return model;
 }
 
-export function toCliModel(model: string, defaultCliModel?: string): string {
-  const stripped = stripModelPrefix(model);
-  const normalized = MODEL_ALIASES[stripped];
-  if (normalized) return normalized;
-
-  // Unknown model — fall back to default if provided
-  if (defaultCliModel) {
-    const fallback = MODEL_ALIASES[defaultCliModel] || defaultCliModel;
-    logger.warn(`Unknown model "${model}", falling back to "${fallback}"`);
-    return fallback;
-  }
-
-  throw badRequest(`Unknown model: ${model}. Supported models: ${Object.keys(MODEL_ALIASES).join(', ')}`);
+function resolveFamily(model: string): 'opus' | 'sonnet' | 'haiku' | null {
+  const match = FAMILY_REGEX.exec(model);
+  return match ? (match[1].toLowerCase() as 'opus' | 'sonnet' | 'haiku') : null;
 }
 
-export function toApiModel(cliModel: string): string {
-  return CLI_TO_API_MODEL[cliModel] || cliModel;
+export function toCliModel(model: string): string {
+  const stripped = stripModelPrefix(model);
+  const family = resolveFamily(stripped);
+  if (family) {
+    return family;
+  }
+
+  throw badRequest(
+    `Unknown model: "${model}". Supported families: opus, sonnet, haiku ` +
+    `(e.g. "opus", "claude-opus-4-7", "sonnet", "haiku-4-5").`
+  );
 }
 
 export function validateEffort(model: string, effort: string | undefined, defaultEffort: string): string | null {
   const stripped = stripModelPrefix(model);
-  const cliModel = MODEL_ALIASES[stripped] || stripped;
-  const allowed = EFFORT_BY_MODEL[cliModel];
+  const family = resolveFamily(stripped);
+  const allowed = family ? EFFORT_BY_MODEL[family] : undefined;
 
   if (!allowed || allowed.length === 0) {
     return null; // Model doesn't support effort


### PR DESCRIPTION
## Summary
- resolve request models by family prefix (`opus`, `sonnet`, `haiku`) instead of a pinned per-version alias table
- fail loud with `400 invalid_request_error` for unknown model families rather than silently routing to `DEFAULT_MODEL`
- update README and CLAUDE docs to describe the family-prefix rule and the new error behavior

## Root cause
`src/translation/model-map.ts` only recognized a hard-coded alias list for the currently known Anthropic versions. Any miss would log a warning and fall back to Sonnet via `DEFAULT_MODEL`, which silently changed the requested model and required proxy updates for each new minor model release.

## What changed
- replaced `MODEL_ALIASES` with family-based resolution after stripping `claude-code-cli/` and `openai/`
- removed the request-path fallback from `toCliModel()` and now throw a `400` for unsupported families
- reused the same resolver for `validateEffort()`
- removed the unused reverse-mapping code from `model-map.ts`
- updated the only `toCliModel()` callsite in `args-builder.ts`
- refreshed the docs to match the new routing rules

## Impact
Existing supported model families continue to work, while future versioned names like `claude-opus-4-7`, `opus-5`, and `sonnet-4-7` now route to the correct CLI family automatically. Typos and foreign model families now fail visibly instead of being silently downgraded to Sonnet.

## Validation
- `npm run build`
- local HTTP smoke checks against the built proxy:
  - `/v1/models` unchanged
  - `gpt-4` -> `400 invalid_request_error`
  - `claude-instant-1` -> `400 invalid_request_error`
  - debug spawn logs showed `claude-opus-4-7` -> `--model opus`
  - debug spawn logs showed `claude-code-cli/claude-opus-4-7` -> `--model opus`
  - debug spawn logs showed `opus-5` -> `--model opus`
  - debug spawn logs showed `sonnet-4-7` -> `--model sonnet`
  - debug spawn logs showed `haiku` requests omit `--effort`, preserving current behavior

Closes #14
