### PR TITLE
fix: forward cache token usage in non-streaming /v1/messages

### DIFF
--- a/src/translation/cli-to-anthropic.ts
+++ b/src/translation/cli-to-anthropic.ts
@@ -22,7 +22,12 @@ export async function collectAnthropicResponse(
   let stopReason: AnthropicMessagesResponse['stop_reason'] = null;
   let stopSequence: string | null = null;
   const contentBlocks: AnthropicResponseContentBlock[] = [];
-  let usage: AnthropicUsage = { input_tokens: 0, output_tokens: 0 };
+  let usage: AnthropicUsage = {
+    input_tokens: 0,
+    output_tokens: 0,
+    cache_creation_input_tokens: 0,
+    cache_read_input_tokens: 0,
+  };
   let hasResult = false;
   let sawToolUseStop = false;
   let rateLimitInfo: RateLimitInfo | undefined;
@@ -40,6 +45,8 @@ export async function collectAnthropicResponse(
           usage = {
             input_tokens: inner.message.usage.input_tokens,
             output_tokens: inner.message.usage.output_tokens,
+            cache_creation_input_tokens: inner.message.usage.cache_creation_input_tokens ?? 0,
+            cache_read_input_tokens: inner.message.usage.cache_read_input_tokens ?? 0,
           };
         }
 
@@ -129,6 +136,10 @@ export async function collectAnthropicResponse(
         if (event.subtype === 'success' && event.usage) {
           usage.input_tokens = event.usage.input_tokens;
           usage.output_tokens = event.usage.output_tokens;
+          usage.cache_creation_input_tokens =
+            event.usage.cache_creation_input_tokens ?? usage.cache_creation_input_tokens;
+          usage.cache_read_input_tokens =
+            event.usage.cache_read_input_tokens ?? usage.cache_read_input_tokens;
         }
         break;
       }


### PR DESCRIPTION
## Summary

- Initialize the local `usage` accumulator in `collectAnthropicResponse` with all four token fields, then forward `cache_creation_input_tokens` and `cache_read_input_tokens` from both `message_start` and the final `result` event.
- Brings the non-streaming Anthropic response shape to parity with the streaming variant and real Anthropic, unblocking downstream cost analytics (e.g. ccusage) that key off `usage.cache_*_input_tokens`.

## Test plan

- [x] `npm run build` (zero errors)
- [ ] Manual repro before/after the fix:
  ```bash
  curl -s -X POST http://127.0.0.1:4523/v1/messages \
    -H "Content-Type: application/json" \
    -d '{"model":"claude-haiku-4-5","max_tokens":50,"messages":[{"role":"user","content":"Say hi"}]}' \
    | jq .usage
  ```
  After the fix, `usage` should include `cache_creation_input_tokens` and `cache_read_input_tokens` (matching the streaming variant of the same request).

Closes #16

🤖 Generated with [Claude Code](https://claude.com/claude-code)