### PR TITLE
feat: emit final usage chunk on /v1/chat/completions stream when stream_options.include_usage is true

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -295,6 +295,10 @@ These are accepted but ignored (a `x-proxy-unsupported` response header lists th
 - `frequency_penalty`, `presence_penalty` — OpenAI-specific, no equivalent
 - `n > 1` — only single completion supported
 
+## OpenAI Streaming Options
+
+`POST /v1/chat/completions` honors `stream_options.include_usage`. When `stream: true` and `stream_options: {include_usage: true}` are both set, the proxy emits one extra chunk with empty `choices` and a populated `usage` object immediately before `data: [DONE]`. Usage is suppressed only on rate-limit errors, where the SSE error event already terminates the stream. Only `include_usage` is honored — other fields under `stream_options` are ignored.
+
 ## OpenClaw Integration
 
 The proxy supports plug-and-play operation with [OpenClaw](https://github.com/AntonioAEMartins/claude-code-proxy/issues/3). The following features are applied automatically on OpenAI-format requests:

--- a/README.md
+++ b/README.md
@@ -140,10 +140,13 @@ const stream = await client.chat.completions.create({
   model: "claude-sonnet-4",
   messages: [{ role: "user", content: "Write a haiku" }],
   stream: true,
+  // Optional: emit a final chunk with usage totals before [DONE].
+  stream_options: { include_usage: true },
 });
 
 for await (const chunk of stream) {
   process.stdout.write(chunk.choices[0]?.delta?.content || "");
+  if (chunk.usage) console.error("usage:", chunk.usage);
 }
 ```
 

--- a/src/protocol/openai-types.ts
+++ b/src/protocol/openai-types.ts
@@ -67,6 +67,10 @@ export interface OpenAIResponseFormat {
   };
 }
 
+export interface OpenAIStreamOptions {
+  include_usage?: boolean;
+}
+
 export interface OpenAIChatCompletionRequest {
   model: string;
   messages: OpenAIChatMessage[];
@@ -76,6 +80,7 @@ export interface OpenAIChatCompletionRequest {
   top_p?: number;
   n?: number;
   stream?: boolean;
+  stream_options?: OpenAIStreamOptions;
   stop?: string | string[];
   frequency_penalty?: number;
   presence_penalty?: number;
@@ -141,6 +146,8 @@ export interface OpenAIChatCompletionChunk {
   model: string;
   choices: OpenAIStreamChoice[];
   system_fingerprint: string | null;
+  /** Populated only on the optional final chunk when stream_options.include_usage is true. */
+  usage?: OpenAICompletionUsage;
 }
 
 // ── Models endpoint ──

--- a/src/routes/openai-chat-completions.ts
+++ b/src/routes/openai-chat-completions.ts
@@ -219,8 +219,10 @@ export async function handleChatCompletions(
     // SSE connection confirmation — lets clients know the stream is live
     res.write(':ok\n\n');
 
+    const includeUsage = body.stream_options?.include_usage === true;
+
     try {
-      for await (const chunk of cliToOpenAISSE(events, reverseToolMap)) {
+      for await (const chunk of cliToOpenAISSE(events, reverseToolMap, includeUsage)) {
         if (!res.writable) break;
         res.write(chunk);
       }

--- a/src/translation/cli-to-openai-stream.ts
+++ b/src/translation/cli-to-openai-stream.ts
@@ -1,7 +1,8 @@
 import type { CliEvent } from '../protocol/cli-types.js';
-import type { OpenAIChatCompletionChunk } from '../protocol/openai-types.js';
+import type { OpenAIChatCompletionChunk, OpenAICompletionUsage } from '../protocol/openai-types.js';
 import { logger } from '../util/logger.js';
 import { stripMcpToolPrefix } from '../tools/tool-translator.js';
+import { updateUsageFromEvent } from './cli-to-openai.js';
 
 function makeChunk(
   id: string,
@@ -19,21 +20,49 @@ function makeChunk(
   };
 }
 
+function makeUsageChunk(
+  id: string,
+  model: string,
+  usage: OpenAICompletionUsage,
+): OpenAIChatCompletionChunk {
+  return {
+    id,
+    object: 'chat.completion.chunk',
+    created: Math.floor(Date.now() / 1000),
+    model,
+    choices: [],
+    system_fingerprint: null,
+    usage,
+  };
+}
+
 /**
  * Transform CLI events into OpenAI SSE text chunks.
  * @param reverseToolMap - Optional map to translate CLI tool names back to client names
+ * @param includeUsage   - When true, emit a final chunk with empty `choices` and a populated
+ *                         `usage` object before `[DONE]`, per the OpenAI streaming contract for
+ *                         `stream_options.include_usage: true`. The chunk is suppressed on
+ *                         rate-limit errors, since those terminate the stream with an error event.
  */
 export async function* cliToOpenAISSE(
   events: AsyncGenerator<CliEvent>,
   reverseToolMap?: Record<string, string>,
+  includeUsage = false,
 ): AsyncGenerator<string> {
   let messageId = '';
   let model = '';
   let toolCallIndex = -1;
   let sentRole = false;
   let sawToolUseStop = false;
+  const usage: OpenAICompletionUsage = {
+    prompt_tokens: 0,
+    completion_tokens: 0,
+    total_tokens: 0,
+  };
 
   for await (const event of events) {
+    updateUsageFromEvent(usage, event);
+
     if (event.type !== 'stream_event') {
       if (event.type === 'system') {
         model = event.model;
@@ -129,6 +158,9 @@ export async function* cliToOpenAISSE(
         // placeholder result — that garbage must never reach the client.
         if (sawToolUseStop) {
           logger.debug('Stopping stream after tool_use turn (intercepting MCP placeholder turn)');
+          if (includeUsage) {
+            yield `data: ${JSON.stringify(makeUsageChunk(messageId, model, usage))}\n\n`;
+          }
           yield 'data: [DONE]\n\n';
           return;
         }
@@ -143,5 +175,8 @@ export async function* cliToOpenAISSE(
     }
   }
 
+  if (includeUsage) {
+    yield `data: ${JSON.stringify(makeUsageChunk(messageId, model, usage))}\n\n`;
+  }
   yield 'data: [DONE]\n\n';
 }

--- a/src/translation/cli-to-openai.ts
+++ b/src/translation/cli-to-openai.ts
@@ -11,6 +11,29 @@ interface AccumulatedToolCall {
 }
 
 /**
+ * Update the running usage totals from a single CLI event. Mutates `usage` in place.
+ * Shared between the streaming and non-streaming OpenAI translators so the two paths
+ * report identical token counts for the same event sequence.
+ */
+export function updateUsageFromEvent(usage: OpenAICompletionUsage, event: CliEvent): void {
+  if (event.type === 'stream_event') {
+    const inner = event.event;
+    if (inner.type === 'message_start') {
+      usage.prompt_tokens = inner.message.usage.input_tokens;
+    } else if (inner.type === 'message_delta') {
+      usage.completion_tokens = inner.usage.output_tokens;
+      usage.total_tokens = usage.prompt_tokens + usage.completion_tokens;
+    }
+    return;
+  }
+  if (event.type === 'result' && event.subtype === 'success' && event.usage) {
+    usage.prompt_tokens = event.usage.input_tokens;
+    usage.completion_tokens = event.usage.output_tokens;
+    usage.total_tokens = usage.prompt_tokens + usage.completion_tokens;
+  }
+}
+
+/**
  * Collect all CLI events and build a non-streaming OpenAI Chat Completion response.
  * @param reverseToolMap - Optional map to translate CLI tool names back to client names
  */
@@ -34,6 +57,8 @@ export async function collectOpenAIResponse(
   let rateLimitInfo: RateLimitInfo | undefined;
 
   eventLoop: for await (const event of events) {
+    updateUsageFromEvent(usage, event);
+
     switch (event.type) {
       case 'stream_event': {
         const inner = event.event;
@@ -41,7 +66,6 @@ export async function collectOpenAIResponse(
         if (inner.type === 'message_start') {
           messageId = inner.message.id || `chatcmpl-${crypto.randomUUID().replace(/-/g, '')}`;
           model = inner.message.model || model;
-          usage.prompt_tokens = inner.message.usage.input_tokens;
         }
 
         if (inner.type === 'content_block_start') {
@@ -72,8 +96,6 @@ export async function collectOpenAIResponse(
           } else {
             finishReason = 'stop';
           }
-          usage.completion_tokens = inner.usage.output_tokens;
-          usage.total_tokens = usage.prompt_tokens + usage.completion_tokens;
         }
 
         // After message_stop for a tool_use turn, stop consuming events.
@@ -90,11 +112,6 @@ export async function collectOpenAIResponse(
       case 'result': {
         if (event.subtype === 'error') {
           throw serverError(event.result || 'CLI returned an error');
-        }
-        if (event.subtype === 'success' && event.usage) {
-          usage.prompt_tokens = event.usage.input_tokens;
-          usage.completion_tokens = event.usage.output_tokens;
-          usage.total_tokens = usage.prompt_tokens + usage.completion_tokens;
         }
         break;
       }


### PR DESCRIPTION
## Summary

- Honors `stream_options: {include_usage: true}` on `POST /v1/chat/completions` by emitting one final chunk with empty `choices` and a populated `usage` object before `data: [DONE]`, matching the OpenAI streaming contract.
- Wires the flag end-to-end: extends `OpenAIChatCompletionRequest`, threads `includeUsage` through the SSE translator, and extracts a shared `updateUsageFromEvent` helper so streaming and non-streaming track tokens identically.
- Without `include_usage`, behavior is unchanged.

Closes #18.

## Why

OpenAI SDKs (`openai-python`, `openai-node`, `langchain`) and downstream cost/billing/analytics tooling rely on the final-chunk usage for proxied streams. Today the proxy unconditionally emits `[DONE]` and those callers see `null`/`undefined`.

## Implementation notes

- `OpenAIChatCompletionChunk.usage` is now optional so per-delta chunks stay slim while the final chunk can carry totals.
- The early-return path that swallows the MCP placeholder turn after `tool_use` also emits the usage chunk before `[DONE]` when `include_usage` is true.
- Usage is intentionally suppressed on rate-limit errors — the SSE error event already terminates the stream meaningfully.
- Usage shape is kept identical to the non-streaming response (`prompt_tokens` / `completion_tokens` / `total_tokens`). When the companion non-streaming `prompt_tokens_details.cached_tokens` issue lands, both paths can be extended together by updating `updateUsageFromEvent` in `src/translation/cli-to-openai.ts`.

## Test plan

- [x] `npm run build` compiles with zero errors
- [x] Local unit smoke test against the compiled module: feeds a synthetic CLI event sequence (`message_start` → `content_block_*` → `message_delta` → `message_stop` → `result`) through `cliToOpenAISSE` and verifies:
  - With `include_usage=true`: emits 5 chunks ending with usage chunk (`choices: []`, `usage: {prompt_tokens: 11, completion_tokens: 7, total_tokens: 18}`) followed by `[DONE]`
  - With `include_usage=false`: unchanged 4-chunk shape ending in `[DONE]`, no `usage` field on any chunk
  - Non-final chunks never carry `usage`
- [ ] Manual end-to-end against the live CLI:
  ```bash
  curl -s -N -X POST http://127.0.0.1:4523/v1/chat/completions \
    -H "Content-Type: application/json" \
    -d '{"model":"claude-haiku-4-5","max_tokens":50,"stream":true,
         "stream_options":{"include_usage":true},
         "messages":[{"role":"user","content":"Say hi in 3 words."}]}' \
    | tail -10
  ```
  Expected: a chunk with `"choices":[]` and `"usage":{...}` immediately before `data: [DONE]`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)