### PR TITLE
feat: surface cache token info in OpenAI /v1/chat/completions usage

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -287,6 +287,38 @@ The proxy forwards quota information from the CLI's `rate_limit_event` as standa
 
 All three headers are listed in `Access-Control-Expose-Headers` so browser clients can read them.
 
+## Usage Object — Cache Token Fields
+
+Both API surfaces forward Anthropic's `cache_creation_input_tokens` and `cache_read_input_tokens` from the CLI's `Usage` payload. Cold-cache requests report `0` rather than dropping the field, so the response shape is consistent on every call.
+
+**Anthropic `/v1/messages`** — fields land directly on `usage`:
+```json
+{
+  "usage": {
+    "input_tokens": 10,
+    "output_tokens": 50,
+    "cache_creation_input_tokens": 0,
+    "cache_read_input_tokens": 8
+  }
+}
+```
+
+**OpenAI `/v1/chat/completions`** — `cache_read_input_tokens` is mirrored to the OpenAI-spec `prompt_tokens_details.cached_tokens`. The Anthropic-style keys are also surfaced so clients that grok them keep cache-creation visibility (OpenAI has no native field for cache-write tokens):
+```json
+{
+  "usage": {
+    "prompt_tokens": 10,
+    "completion_tokens": 50,
+    "total_tokens": 60,
+    "prompt_tokens_details": { "cached_tokens": 8 },
+    "cache_creation_input_tokens": 0,
+    "cache_read_input_tokens": 8
+  }
+}
+```
+
+Streaming responses already pass these fields through verbatim from the CLI's `stream_event` payloads.
+
 ## Unsupported Parameters
 
 These are accepted but ignored (a `x-proxy-unsupported` response header lists them):

--- a/src/protocol/openai-types.ts
+++ b/src/protocol/openai-types.ts
@@ -96,10 +96,17 @@ export interface OpenAIChoice {
   finish_reason: 'stop' | 'tool_calls' | 'length' | 'content_filter' | null;
 }
 
+export interface OpenAIPromptTokensDetails {
+  cached_tokens?: number;
+}
+
 export interface OpenAICompletionUsage {
   prompt_tokens: number;
   completion_tokens: number;
   total_tokens: number;
+  prompt_tokens_details?: OpenAIPromptTokensDetails;
+  cache_creation_input_tokens?: number;
+  cache_read_input_tokens?: number;
 }
 
 export interface OpenAIChatCompletionResponse {

--- a/src/translation/cli-to-openai.ts
+++ b/src/translation/cli-to-openai.ts
@@ -29,7 +29,14 @@ export async function collectOpenAIResponse(
   let finishReason: 'stop' | 'tool_calls' | 'length' | null = null;
   const toolCalls: AccumulatedToolCall[] = [];
   let currentToolCallIndex = -1;
-  let usage: OpenAICompletionUsage = { prompt_tokens: 0, completion_tokens: 0, total_tokens: 0 };
+  let usage: OpenAICompletionUsage = {
+    prompt_tokens: 0,
+    completion_tokens: 0,
+    total_tokens: 0,
+    cache_creation_input_tokens: 0,
+    cache_read_input_tokens: 0,
+    prompt_tokens_details: { cached_tokens: 0 },
+  };
   let sawToolUseStop = false;
   let rateLimitInfo: RateLimitInfo | undefined;
 
@@ -42,6 +49,11 @@ export async function collectOpenAIResponse(
           messageId = inner.message.id || `chatcmpl-${crypto.randomUUID().replace(/-/g, '')}`;
           model = inner.message.model || model;
           usage.prompt_tokens = inner.message.usage.input_tokens;
+          const cacheRead = inner.message.usage.cache_read_input_tokens ?? 0;
+          const cacheCreate = inner.message.usage.cache_creation_input_tokens ?? 0;
+          usage.cache_read_input_tokens = cacheRead;
+          usage.cache_creation_input_tokens = cacheCreate;
+          usage.prompt_tokens_details = { cached_tokens: cacheRead };
         }
 
         if (inner.type === 'content_block_start') {
@@ -95,6 +107,13 @@ export async function collectOpenAIResponse(
           usage.prompt_tokens = event.usage.input_tokens;
           usage.completion_tokens = event.usage.output_tokens;
           usage.total_tokens = usage.prompt_tokens + usage.completion_tokens;
+          if (event.usage.cache_read_input_tokens !== undefined) {
+            usage.cache_read_input_tokens = event.usage.cache_read_input_tokens;
+            usage.prompt_tokens_details = { cached_tokens: event.usage.cache_read_input_tokens };
+          }
+          if (event.usage.cache_creation_input_tokens !== undefined) {
+            usage.cache_creation_input_tokens = event.usage.cache_creation_input_tokens;
+          }
         }
         break;
       }


### PR DESCRIPTION
## Summary

- Mirror Anthropic's `cache_creation_input_tokens` / `cache_read_input_tokens` through the OpenAI non-streaming translator so cache-hit visibility isn't dropped on `/v1/chat/completions`.
- Surface OpenAI's spec `prompt_tokens_details.cached_tokens` for clients that read it, plus the Anthropic-style keys for full cache-creation fidelity (OpenAI has no native field for cache-write tokens).
- Document the new `usage` shape in `CLAUDE.md`.

## Changes

- `src/protocol/openai-types.ts` — extend `OpenAICompletionUsage` with `prompt_tokens_details`, `cache_creation_input_tokens`, and `cache_read_input_tokens`.
- `src/translation/cli-to-openai.ts` — initialize all four fields, then carry them through `message_start` and the `result` event the same way `cli-to-anthropic.ts` does.
- `CLAUDE.md` — new "Usage Object — Cache Token Fields" section under the rate-limit headers section.

## Behavior

Before:
```json
{ "prompt_tokens": 10, "completion_tokens": 50, "total_tokens": 60 }
```

After (cache hit):
```json
{
  "prompt_tokens": 10,
  "completion_tokens": 50,
  "total_tokens": 60,
  "prompt_tokens_details": { "cached_tokens": 8 },
  "cache_creation_input_tokens": 0,
  "cache_read_input_tokens": 8
}
```

Cold-cache requests report `0` rather than dropping the field, matching the Anthropic accumulator's behavior.

## Test plan

- [x] `npm run build` compiles with zero errors
- [ ] Manual: hit `/v1/chat/completions` non-streaming twice with the same prompt; verify second call shows non-zero `prompt_tokens_details.cached_tokens` and `cache_read_input_tokens`
- [ ] Manual: confirm cold-cache request still returns `cache_read_input_tokens: 0` (no field omission)
- [ ] Confirm OpenAI streaming path is unaffected (covered by issue #18)

Closes #17.

🤖 Generated with [Claude Code](https://claude.com/claude-code)