### PR TITLE
fix: restore cache token usage on OpenAI responses + forward to streaming usage chunk

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -287,6 +287,38 @@ The proxy forwards quota information from the CLI's `rate_limit_event` as standa
 
 All three headers are listed in `Access-Control-Expose-Headers` so browser clients can read them.
 
+## Usage Object — Cache Token Fields
+
+Both API surfaces forward Anthropic's `cache_creation_input_tokens` and `cache_read_input_tokens` from the CLI's `Usage` payload. Cold-cache requests report `0` rather than dropping the field, so the response shape is consistent on every call.
+
+**Anthropic `/v1/messages`** — fields land directly on `usage`:
+```json
+{
+  "usage": {
+    "input_tokens": 10,
+    "output_tokens": 50,
+    "cache_creation_input_tokens": 0,
+    "cache_read_input_tokens": 8
+  }
+}
+```
+
+**OpenAI `/v1/chat/completions`** — `cache_read_input_tokens` is mirrored to the OpenAI-spec `prompt_tokens_details.cached_tokens`. The Anthropic-style keys are also surfaced so clients that grok them keep cache-creation visibility (OpenAI has no native field for cache-write tokens):
+```json
+{
+  "usage": {
+    "prompt_tokens": 10,
+    "completion_tokens": 50,
+    "total_tokens": 60,
+    "prompt_tokens_details": { "cached_tokens": 8 },
+    "cache_creation_input_tokens": 0,
+    "cache_read_input_tokens": 8
+  }
+}
+```
+
+This shape is identical on both the non-streaming response and the final streaming chunk emitted when `stream_options.include_usage: true`.
+
 ## Unsupported Parameters
 
 These are accepted but ignored (a `x-proxy-unsupported` response header lists them):

--- a/src/protocol/openai-types.ts
+++ b/src/protocol/openai-types.ts
@@ -101,10 +101,20 @@ export interface OpenAIChoice {
   finish_reason: 'stop' | 'tool_calls' | 'length' | 'content_filter' | null;
 }
 
+export interface OpenAIPromptTokensDetails {
+  cached_tokens: number;
+}
+
 export interface OpenAICompletionUsage {
   prompt_tokens: number;
   completion_tokens: number;
   total_tokens: number;
+  /** Tokens written to the prompt cache (Anthropic-style). Optional. */
+  cache_creation_input_tokens?: number;
+  /** Tokens served from the prompt cache (Anthropic-style). Optional. */
+  cache_read_input_tokens?: number;
+  /** OpenAI-shaped cache detail. `cached_tokens` mirrors `cache_read_input_tokens`. */
+  prompt_tokens_details?: OpenAIPromptTokensDetails;
 }
 
 export interface OpenAIChatCompletionResponse {

--- a/src/translation/cli-to-openai-stream.ts
+++ b/src/translation/cli-to-openai-stream.ts
@@ -2,7 +2,7 @@ import type { CliEvent } from '../protocol/cli-types.js';
 import type { OpenAIChatCompletionChunk, OpenAICompletionUsage } from '../protocol/openai-types.js';
 import { logger } from '../util/logger.js';
 import { stripMcpToolPrefix } from '../tools/tool-translator.js';
-import { updateUsageFromEvent } from './cli-to-openai.js';
+import { makeEmptyUsage, updateUsageFromEvent } from './cli-to-openai.js';
 
 function makeChunk(
   id: string,
@@ -54,11 +54,7 @@ export async function* cliToOpenAISSE(
   let toolCallIndex = -1;
   let sentRole = false;
   let sawToolUseStop = false;
-  const usage: OpenAICompletionUsage = {
-    prompt_tokens: 0,
-    completion_tokens: 0,
-    total_tokens: 0,
-  };
+  const usage: OpenAICompletionUsage = makeEmptyUsage();
 
   for await (const event of events) {
     updateUsageFromEvent(usage, event);

--- a/src/translation/cli-to-openai.ts
+++ b/src/translation/cli-to-openai.ts
@@ -1,4 +1,4 @@
-import type { CliEvent, RateLimitInfo } from '../protocol/cli-types.js';
+import type { CliEvent, RateLimitInfo, Usage } from '../protocol/cli-types.js';
 import type { OpenAIChatCompletionResponse, OpenAIToolCall, OpenAICompletionUsage } from '../protocol/openai-types.js';
 import { logger } from '../util/logger.js';
 import { serverError, rateLimited } from '../util/errors.js';
@@ -11,15 +11,41 @@ interface AccumulatedToolCall {
 }
 
 /**
+ * Build a fresh usage record initialized to zero, including the optional
+ * Anthropic-style cache fields and the OpenAI `prompt_tokens_details` mirror.
+ */
+export function makeEmptyUsage(): OpenAICompletionUsage {
+  return {
+    prompt_tokens: 0,
+    completion_tokens: 0,
+    total_tokens: 0,
+    cache_creation_input_tokens: 0,
+    cache_read_input_tokens: 0,
+    prompt_tokens_details: { cached_tokens: 0 },
+  };
+}
+
+function applyCacheFields(usage: OpenAICompletionUsage, cliUsage: Usage): void {
+  if (cliUsage.cache_read_input_tokens !== undefined) {
+    usage.cache_read_input_tokens = cliUsage.cache_read_input_tokens;
+    usage.prompt_tokens_details = { cached_tokens: cliUsage.cache_read_input_tokens };
+  }
+  if (cliUsage.cache_creation_input_tokens !== undefined) {
+    usage.cache_creation_input_tokens = cliUsage.cache_creation_input_tokens;
+  }
+}
+
+/**
  * Update the running usage totals from a single CLI event. Mutates `usage` in place.
  * Shared between the streaming and non-streaming OpenAI translators so the two paths
- * report identical token counts for the same event sequence.
+ * report identical token counts (including cache fields) for the same event sequence.
  */
 export function updateUsageFromEvent(usage: OpenAICompletionUsage, event: CliEvent): void {
   if (event.type === 'stream_event') {
     const inner = event.event;
     if (inner.type === 'message_start') {
       usage.prompt_tokens = inner.message.usage.input_tokens;
+      applyCacheFields(usage, inner.message.usage);
     } else if (inner.type === 'message_delta') {
       usage.completion_tokens = inner.usage.output_tokens;
       usage.total_tokens = usage.prompt_tokens + usage.completion_tokens;
@@ -30,6 +56,7 @@ export function updateUsageFromEvent(usage: OpenAICompletionUsage, event: CliEve
     usage.prompt_tokens = event.usage.input_tokens;
     usage.completion_tokens = event.usage.output_tokens;
     usage.total_tokens = usage.prompt_tokens + usage.completion_tokens;
+    applyCacheFields(usage, event.usage);
   }
 }
 
@@ -52,7 +79,7 @@ export async function collectOpenAIResponse(
   let finishReason: 'stop' | 'tool_calls' | 'length' | null = null;
   const toolCalls: AccumulatedToolCall[] = [];
   let currentToolCallIndex = -1;
-  let usage: OpenAICompletionUsage = { prompt_tokens: 0, completion_tokens: 0, total_tokens: 0 };
+  const usage: OpenAICompletionUsage = makeEmptyUsage();
   let sawToolUseStop = false;
   let rateLimitInfo: RateLimitInfo | undefined;
 


### PR DESCRIPTION
## Summary

The squashed merge of #20 landed on top of #19 in a way that effectively reverted #19's additions to `OpenAICompletionUsage` and the inline cache-forwarding logic in `collectOpenAIResponse`. On `main` today:

- `OpenAICompletionUsage` is back to `{prompt_tokens, completion_tokens, total_tokens}` only — no `cache_creation_input_tokens`, no `cache_read_input_tokens`, no `prompt_tokens_details.cached_tokens`.
- `collectOpenAIResponse` no longer forwards the CLI's cache numbers.
- The streaming `include_usage` chunk added in #20 inherits the same lean shape — no cache info even when the CLI provides it.

This PR restores the cache-token forwarding for both paths and consolidates the accounting so they cannot drift again.

## Changes

- `src/protocol/openai-types.ts` — re-adds optional `cache_creation_input_tokens`, `cache_read_input_tokens`, and `prompt_tokens_details: OpenAIPromptTokensDetails` to `OpenAICompletionUsage`.
- `src/translation/cli-to-openai.ts`
  - New `applyCacheFields(usage, cliUsage)` helper.
  - `updateUsageFromEvent` now calls it on `message_start` and `result.success`, so streaming and non-streaming track the cache fields with one code path.
  - New `makeEmptyUsage()` factory so initializers can't drift.
  - `collectOpenAIResponse` switches to `makeEmptyUsage()` and drops its now-redundant inline cache logic — the helper handles everything.
- `src/translation/cli-to-openai-stream.ts` — uses `makeEmptyUsage()`. The final `include_usage` chunk now carries the same cache numbers as the non-streaming response.

No `OpenAIChatCompletionRequest` shape changes. No route changes. The optional type extension is backwards compatible with any client that reads only the legacy fields.

## Why this matters

- Cost/billing/analytics pipelines built against OpenAI streaming need `cached_tokens` to compute true cache hit rates and accurate cost.
- #19's intent (mirror Anthropic's cache fields onto the OpenAI shape) was reverted by the merge order; this restores it.
- Keeps streaming and non-streaming usage shapes byte-identical for the same CLI event sequence.

## Test plan

- [x] `npm run build` — clean compile.
- [x] Local unit smoke test: synthesizes a CLI event sequence with `cache_creation_input_tokens: 4` and `cache_read_input_tokens: 7`, then asserts:
  - Non-streaming `response.usage` ends up at `{prompt: 11, completion: 7, total: 18, cache_creation_input_tokens: 4, cache_read_input_tokens: 7, prompt_tokens_details: {cached_tokens: 7}}`.
  - Streaming with `include_usage: true` emits a final chunk whose `usage` is byte-identical to the non-streaming response.
  - Streaming with `include_usage: false` is unchanged — no chunk carries `usage`.
  - Non-final streaming chunks never carry `usage`.
- [ ] Manual end-to-end against the live CLI:
  ```bash
  curl -s -N -X POST http://127.0.0.1:4523/v1/chat/completions \
    -H "Content-Type: application/json" \
    -d '{"model":"claude-haiku-4-5","max_tokens":50,"stream":true,
         "stream_options":{"include_usage":true},
         "messages":[{"role":"user","content":"Say hi in 3 words."}]}' \
    | tail -10
  ```
  Expected: a chunk with `"choices":[]` and `"usage": {... "prompt_tokens_details": {"cached_tokens": ...}}` immediately before `data: [DONE]`.

## Context

Follow-up to #18 / #19 / #20. Originally pushed as a second commit on the #20 branch, but that PR was already merged before the second commit could be reviewed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)